### PR TITLE
hdmi: add 'vout_mode=*' to set DVI signal on HDMI

### DIFF
--- a/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_main.c
+++ b/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_main.c
@@ -638,7 +638,7 @@ static int set_disp_mode_auto(void)
 	if ((vic_ready != HDMI_Unkown) && (vic_ready == vic) && (strstr(fmt_attr,"now") == NULL)) {
 		hdmi_print(IMP, SYS "[%s] ALREADY init VIC = %d\n",
 			__func__, vic);
-		if (hdev->RXCap.IEEEOUI == 0) {
+		if (hdev->RXCap.IEEEOUI == 0 || aml_voutmode()) {
 			/* DVI case judgement. In uboot, directly output HDMI
 			 * mode
 			 */

--- a/drivers/amlogic/hdmi/hdmi_tx_20/hw/hdmi_tx_hw.c
+++ b/drivers/amlogic/hdmi/hdmi_tx_20/hw/hdmi_tx_hw.c
@@ -2024,6 +2024,8 @@ next:
 	mdelay(1);
 	hdmitx_set_reg_bits(HDMITX_DWC_FC_INVIDCONF, 1, 3, 1);
 
+    hdmitx_hdmi_dvi_config(hdev, aml_voutmode() != VOUTMODE_HDMI);
+
 	return 0;
 }
 
@@ -4922,3 +4924,20 @@ static void hdmitx_set_hw(struct hdmitx_dev *hdev)
 			hdev->para->cs);
 	return;
 }
+
+static int dvi_mode = VOUTMODE_HDMI;
+
+int aml_voutmode(void)
+{
+	return dvi_mode;
+}
+EXPORT_SYMBOL(aml_voutmode);
+
+static  int __init vout_setup(char *s)
+{
+	dvi_mode = VOUTMODE_HDMI;
+	if (!strcmp(s, "dvi"))
+		dvi_mode = VOUTMODE_DVI;
+	return 0;
+}
+__setup("vout_mode=", vout_setup);

--- a/include/linux/amlogic/hdmi_tx/hdmi_info_global.h
+++ b/include/linux/amlogic/hdmi_tx/hdmi_info_global.h
@@ -340,4 +340,8 @@ struct hdmitx_info {
 	/* ------------------------------------------------------- */
 };
 
+#define VOUTMODE_HDMI           0x00
+#define VOUTMODE_DVI            0x01
+int aml_voutmode(void);
+
 #endif  /* _HDMI_RX_GLOBAL_H */


### PR DESCRIPTION
Allow setting dvi mode for displays who don't specify that they require it.

based on
https://github.com/hardkernel/linux/commit/ccba6da64068ea7a38a7a575da3491de088121de