### PR TITLE
Enable multichannel LPCM output over HDMI on s922x

### DIFF
--- a/arch/arm64/boot/dts/amlogic/mesong12_odroid_common.dtsi
+++ b/arch/arm64/boot/dts/amlogic/mesong12_odroid_common.dtsi
@@ -141,6 +141,25 @@
 				sound-dai = <&dummy_codec>;
 			};
 		};
+		
+		aml-audio-card,dai-link@3 {
+			format = "i2s";// "dsp_a";
+			mclk-fs = <256>;
+			bitclock-master = <&aml_tdmb>;
+			frame-master = <&aml_tdmb>;
+			continuous-clock;
+			cpu {
+				sound-dai = <&aml_tdmb>;
+				dai-tdm-slot-tx-mask = <1 1>;
+				dai-tdm-slot-rx-mask = <1 1>;
+				dai-tdm-slot-num = <2>;
+				dai-tdm-slot-width = <32>;
+				system-clock-frequency = <12288000>;
+			};
+			codec {
+				sound-dai = <&dummy_codec>;
+			};
+		};
 	};
 	audiolocker: locker {
 		compatible = "amlogic, audiolocker";
@@ -392,6 +411,19 @@
 				&clkc CLKID_MPLL2>;
 		clock-names = "mclk", "clk_srcpll";
 		i2s2hdmi = <0>;
+		status = "okay";
+	};
+
+	aml_tdmb: tdmb {
+		compatible = "amlogic, g12a-snd-tdmb";
+		#sound-dai-cells = <0>;
+		dai-tdm-lane-slot-mask-in = <0 1 0 0>;
+		dai-tdm-lane-slot-mask-out = <1 1 1 1>;
+		dai-tdm-clk-sel = <1>;
+		clocks = <&clkaudio CLKID_AUDIO_MCLK_B
+				&clkc CLKID_MPLL1>;
+		clock-names = "mclk", "clk_srcpll";
+		i2s2hdmi = <1>;
 		status = "okay";
 	};
 

--- a/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hw/hdmi_tx_hw.c
+++ b/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hw/hdmi_tx_hw.c
@@ -2562,8 +2562,6 @@ static void set_aud_chnls(struct hdmitx_dev *hdev,
 	if ((audio_param->type == CT_PCM) &&
 		(audio_param->channel_num == (2 - 1))) {
 		hdmitx_wr_reg(HDMITX_DWC_FC_AUDSV, 0x11);
-		hdmitx_wr_reg(HDMITX_DWC_FC_AUDSCHNLS7, 0x02);
-		hdmitx_wr_reg(HDMITX_DWC_FC_AUDSCHNLS8, 0xd2);
 	} else {
 		hdmitx_wr_reg(HDMITX_DWC_FC_AUDSV, 0xff);
 	}
@@ -2583,7 +2581,18 @@ static void set_aud_chnls(struct hdmitx_dev *hdev,
 		aud_csb_sampfreq[audio_param->sample_rate], 0, 4); /*CSB 27:24*/
 	hdmitx_set_reg_bits(HDMITX_DWC_FC_AUDSCHNLS7, 0x0, 6, 2); /*CSB 31:30*/
 	hdmitx_set_reg_bits(HDMITX_DWC_FC_AUDSCHNLS7, 0x0, 4, 2); /*CSB 29:28*/
-	hdmitx_set_reg_bits(HDMITX_DWC_FC_AUDSCHNLS8, 0x2, 0, 4); /*CSB 35:32*/
+	switch (audio_param->sample_size) {
+		case SS_16BITS:
+			hdmitx_set_reg_bits(HDMITX_DWC_FC_AUDSCHNLS8, 0x2, 0, 4); /*CSB 35:32*/
+			break;
+		case SS_20BITS:
+			hdmitx_set_reg_bits(HDMITX_DWC_FC_AUDSCHNLS8, 0xa, 0, 4);
+			break;
+		case SS_24BITS:
+		case SS_MAX:
+		default:
+			hdmitx_set_reg_bits(HDMITX_DWC_FC_AUDSCHNLS8, 0xb, 0, 4);
+	}
 	hdmitx_set_reg_bits(HDMITX_DWC_FC_AUDSCHNLS8,  /* CSB 39:36 */
 		aud_csb_ori_sampfreq[audio_param->sample_rate], 4, 4);
 }

--- a/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hw/hdmi_tx_hw.c
+++ b/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hw/hdmi_tx_hw.c
@@ -2803,7 +2803,7 @@ static int hdmitx_set_audmode(struct hdmitx_dev *hdev,
 	if (hdev->aud_output_ch)
 		hdev->tx_aud_src = 1;
 
-	pr_info(HW "hdmitx tx_aud_src = %d\n", hdev->tx_aud_src);
+	pr_info(HW "hdmitx tx_aud_src = %d, audio_param->channel_num = %u, hdev->aud_output_ch = %u\n", hdev->tx_aud_src, audio_param->channel_num, hdev->aud_output_ch);
 
 	/* set_hdmi_audio_source(tx_aud_src ? 1 : 2); */
 	set_hdmi_audio_source(2);

--- a/sound/soc/amlogic/auge/tdm.c
+++ b/sound/soc/amlogic/auge/tdm.c
@@ -35,6 +35,7 @@
 #include <linux/amlogic/cpu_version.h>
 
 #include <linux/amlogic/media/sound/aout_notify.h>
+#include <linux/amlogic/media/vout/hdmi_tx/hdmi_tx_ext.h>
 
 #include "ddr_mngr.h"
 #include "tdm_hw.h"
@@ -468,6 +469,18 @@ static int aml_dai_tdm_prepare(struct snd_pcm_substream *substream,
 		/* i2s source to hdmix */
 		if (p_tdm->i2s2hdmitx) {
 			i2s_to_hdmitx_ctrl(p_tdm->id);
+			if (runtime->channels > 6) {
+				hdmitx_ext_set_i2s_mask(runtime->channels, 0xf);
+			}
+			else if (runtime->channels > 4) {
+				hdmitx_ext_set_i2s_mask(runtime->channels, 0x7);
+			}
+			else if (runtime->channels > 2) {
+				hdmitx_ext_set_i2s_mask(runtime->channels, 0x3);
+			}
+			else {
+				hdmitx_ext_set_i2s_mask(runtime->channels, 0x1);
+			}
 			aout_notifier_call_chain(AOUT_EVENT_IEC_60958_PCM,
 				substream);
 		}

--- a/sound/soc/amlogic/auge/tdm.c
+++ b/sound/soc/amlogic/auge/tdm.c
@@ -30,12 +30,14 @@
 #include <sound/control.h>
 #include <sound/soc.h>
 #include <sound/pcm_params.h>
+#include <sound/tlv.h>
 
 #include <linux/amlogic/clk_measure.h>
 #include <linux/amlogic/cpu_version.h>
 
 #include <linux/amlogic/media/sound/aout_notify.h>
 #include <linux/amlogic/media/vout/hdmi_tx/hdmi_tx_ext.h>
+#include <linux/mutex.h>
 
 #include "ddr_mngr.h"
 #include "tdm_hw.h"
@@ -49,6 +51,42 @@
 
 
 #define DRV_NAME "snd_tdm"
+
+struct channel_speaker_allocation {
+        int channels;
+        int speakers[8];
+};
+
+#define NL	SNDRV_CHMAP_UNKNOWN
+#define NA	SNDRV_CHMAP_NA
+#define FL	SNDRV_CHMAP_FL
+#define FR	SNDRV_CHMAP_FR
+#define RL	SNDRV_CHMAP_RL
+#define RR	SNDRV_CHMAP_RR
+#define LFE	SNDRV_CHMAP_LFE
+#define FC	SNDRV_CHMAP_FC
+#define RLC	SNDRV_CHMAP_RLC
+#define RRC	SNDRV_CHMAP_RRC
+#define RC	SNDRV_CHMAP_RC
+#define FLC	SNDRV_CHMAP_FLC
+#define FRC	SNDRV_CHMAP_FRC
+#define FLH	SNDRV_CHMAP_TFL
+#define FRH	SNDRV_CHMAP_TFR
+#define FLW	SNDRV_CHMAP_FLW
+#define FRW	SNDRV_CHMAP_FRW
+#define TC	SNDRV_CHMAP_TC
+#define FCH	SNDRV_CHMAP_TFC
+
+static struct channel_speaker_allocation channel_allocations[] = {
+/*      	       channel:   7     6    5    4    3     2    1    0  */
+{ .channels = 2,  .speakers = {  NL,   NL,  NL,  NL,  NL,   NL,  FR,  FL } },
+                                 /* 3.1 CEA 0x03 */
+{ .channels = 4,  .speakers = {  NL,   NL,  NL,  NL,  FC,  LFE,  FR,  FL } },
+                                 /* surround51 CEA 0x0b */
+{ .channels = 6,  .speakers = {  NL,   NL,  RR,  RL,  FC,  LFE,  FR,  FL } },
+                                 /* surround71 CEA 0x13 */
+{ .channels = 8,  .speakers = { RRC,  RLC,  RR,  RL,  FC,  LFE,  FR,  FL } },
+};
 
 static int aml_dai_set_tdm_sysclk(struct snd_soc_dai *cpu_dai,
 				int clk_id, unsigned int freq, int dir);
@@ -440,11 +478,178 @@ struct snd_soc_platform_driver aml_tdm_platform = {
 	.pcm_new = aml_tdm_new,
 };
 
+static int aml_dai_tdm_chmap_ctl_tlv(struct snd_kcontrol *kcontrol, int op_flag,
+                                     unsigned int size, unsigned int __user *tlv)
+{
+    unsigned int __user *dst;
+    int count = 0;
+    int i;
+
+    if (size < 8)
+        return -ENOMEM;
+
+    if (put_user(SNDRV_CTL_TLVT_CONTAINER, tlv))
+        return -EFAULT;
+
+    size -= 8;
+    dst = tlv + 2;
+
+    for (i = 0; i < ARRAY_SIZE(channel_allocations); i++)
+    {
+        struct channel_speaker_allocation *ch = &channel_allocations[i];
+        int num_chs = 0;
+        int chs_bytes;
+        int c;
+
+        for (c = 0; c < 8; c++)
+        {
+            if (ch->speakers[c])
+                num_chs++;
+        }
+
+        chs_bytes = num_chs * 4;
+        if (size < 8)
+            return -ENOMEM;
+
+        if (put_user(SNDRV_CTL_TLVT_CHMAP_FIXED, dst) ||
+            put_user(chs_bytes, dst + 1))
+            return -EFAULT;
+
+        dst += 2;
+        size -= 8;
+        count += 8;
+
+        if (size < chs_bytes)
+            return -ENOMEM;
+
+        size -= chs_bytes;
+        count += chs_bytes;
+
+        for (c = 0; c < 8; c++)
+        {
+            int sp = ch->speakers[7 - c];
+            if (sp)
+            {
+                if (put_user(sp, dst))
+                    return -EFAULT;
+                dst++;
+            }
+        }
+    }
+
+    if (put_user(count, tlv + 1))
+        return -EFAULT;
+
+    return 0;
+}
+
+static int aml_dai_tdm_chmap_ctl_get(struct snd_kcontrol *kcontrol,
+                                     struct snd_ctl_elem_value *ucontrol)
+{
+
+    struct snd_pcm_chmap *info = snd_kcontrol_chip(kcontrol);
+    unsigned int idx = snd_ctl_get_ioffidx(kcontrol, &ucontrol->id);
+    struct snd_pcm_substream *substream = snd_pcm_chmap_substream(info, idx);
+	struct aml_chmap *prtd = info->private_data;
+//     struct snd_pcm_runtime *runtime = substream->runtime;
+//     struct aml_runtime_data *prtd = (struct aml_runtime_data *)runtime->private_data;
+    int res = 0, channel;
+
+    if (mutex_lock_interruptible(&prtd->chmap_lock))
+        return -EINTR;
+
+    for (channel=0; channel<8; channel++)
+    {
+        ucontrol->value.integer.value[7 - channel] = channel_allocations[prtd->chmap_layout].speakers[channel];
+    }
+
+unlock:
+    mutex_unlock(&prtd->chmap_lock);
+    return res;
+}
+
+static int aml_dai_tdm_chmap_ctl_put(struct snd_kcontrol *kcontrol,
+                                     struct snd_ctl_elem_value *ucontrol)
+{
+
+    struct snd_pcm_chmap *info = snd_kcontrol_chip(kcontrol);
+    unsigned int idx = snd_ctl_get_ioffidx(kcontrol, &ucontrol->id);
+    struct snd_pcm_substream *substream = snd_pcm_chmap_substream(info, idx);
+	struct aml_chmap *prtd = info->private_data;
+    struct snd_pcm_runtime *runtime = substream->runtime;
+//     struct aml_runtime_data *prtd = (struct aml_runtime_data *)runtime->private_data;
+    int res = 0, channel, layout, matches, matched_layout;
+
+    if (mutex_lock_interruptible(&prtd->chmap_lock))
+        return -EINTR;
+
+    // now check if the channel setup matches one of our layouts
+    for (layout = 0; layout < ARRAY_SIZE(channel_allocations); layout++)
+    {
+        matches = 1;
+
+        for (channel = 0; channel < substream->runtime->channels; channel++)
+        {
+            int sp = ucontrol->value.integer.value[channel];
+            int chan = channel_allocations[layout].speakers[7 - channel];
+
+            if (sp != chan)
+            {
+                matches = 0;
+                break;
+            }
+        }
+
+        if (matches)
+        {
+            matched_layout = layout;
+            break;
+        }
+    }
+
+
+    // default to first layout if we didnt find any
+    if (!matches)
+        matched_layout = 0;
+
+    pr_info("Setting a %d channel layout matching layout #%d\n", runtime->channels, matched_layout);
+
+    prtd->chmap_layout = matched_layout;
+
+unlock:
+    mutex_unlock(&prtd->chmap_lock);
+    return res;
+}
+
+static struct snd_kcontrol *aml_dai_tdm_chmap_kctrl_get(struct snd_pcm_substream *substream)
+{
+    int str;
+
+    if ((substream) && (substream->pcm))
+    {
+        for (str=0; str<2; str++)
+        {
+            if (substream->pcm->streams[str].chmap_kctl)
+            {
+                return substream->pcm->streams[str].chmap_kctl;
+            }
+        }
+    }
+
+    return 0;
+}
+
 static int aml_dai_tdm_prepare(struct snd_pcm_substream *substream,
 			       struct snd_soc_dai *cpu_dai)
 {
+	int ret = 0, i;
 	struct snd_pcm_runtime *runtime = substream->runtime;
 	struct aml_tdm *p_tdm = snd_soc_dai_get_drvdata(cpu_dai);
+	struct snd_soc_pcm_runtime *rtd = substream->private_data;
+	struct snd_pcm_chmap *chmap;
+	struct snd_kcontrol *kctl;
+	struct snd_pcm_chmap *info;
+	struct aml_chmap *prtd;
 	int bit_depth;
 
 	bit_depth = snd_pcm_format_width(runtime->format);
@@ -513,6 +718,37 @@ static int aml_dai_tdm_prepare(struct snd_pcm_substream *substream,
 			tdmout_get_frddr_type(bit_depth));
 		aml_frddr_select_dst(fr, dst);
 		aml_frddr_set_fifos(fr, 0x40, 0x20);
+		
+		// Alsa Channel Mapping API handling
+		if (!aml_dai_tdm_chmap_kctrl_get(substream))
+		{
+			ret = snd_pcm_add_chmap_ctls(substream->pcm, SNDRV_PCM_STREAM_PLAYBACK, NULL, 8, 0, &chmap);
+
+			if (ret < 0)
+			{
+			pr_err("aml_dai_tdm_startup error %d\n", ret);
+			goto out;
+			}
+
+			kctl = chmap->kctl;
+			for (i = 0; i < kctl->count; i++)
+			kctl->vd[i].access |= SNDRV_CTL_ELEM_ACCESS_WRITE;
+
+			kctl->get = aml_dai_tdm_chmap_ctl_get;
+			kctl->put = aml_dai_tdm_chmap_ctl_put;
+			kctl->tlv.c = aml_dai_tdm_chmap_ctl_tlv;
+			
+			info = snd_kcontrol_chip(kctl);
+			prtd = info->private_data;
+			if (prtd == NULL) {
+				prtd = (struct aml_chmap*)kzalloc(sizeof(struct aml_chmap), GFP_KERNEL);
+				info->private_data = prtd;
+			}
+			mutex_init(&prtd->chmap_lock);
+		}
+	out:
+		return ret;
+		
 	} else {
 		struct toddr *to = p_tdm->tddr;
 		enum toddr_src src;

--- a/sound/soc/amlogic/auge/tdm_hw.h
+++ b/sound/soc/amlogic/auge/tdm_hw.h
@@ -20,6 +20,7 @@
 
 #include "audio_io.h"
 #include "regs.h"
+#include <linux/mutex.h>
 
 #define TDM_A	0
 #define TDM_B	1
@@ -67,6 +68,11 @@ struct pcm_setting {
 
 	/* eco or sclk_ws_inv */
 	bool sclk_ws_inv;
+};
+
+struct aml_chmap {
+	struct mutex chmap_lock;
+	int chmap_layout;
 };
 
 extern void aml_tdm_enable(

--- a/sound/soc/amlogic/common/spdif_info.c
+++ b/sound/soc/amlogic/common/spdif_info.c
@@ -128,6 +128,9 @@ void spdif_get_channel_status_info(
 
 void spdif_notify_to_hdmitx(struct snd_pcm_substream *substream)
 {
+	//0 signals audio is coming from spdif rather than i2s
+	hdmitx_ext_set_i2s_mask(0x0, 0x0);
+	
 	if (IEC958_mode_codec == 2) {
 		aout_notifier_call_chain(
 			AOUT_EVENT_RAWDATA_AC_3,


### PR DESCRIPTION
This allows lpcm output over HDMI on s922x devices, with ~minimal changes to fix up switching between tdm/i2s and spdif inputs to hdmitx, and some small fixes to the spdif channel status header to properly indicate 16 vs 24 bit output for lpcm.

Larger change is the forward porting of the ALSA channel mapping api from 3.14 to get the correct channel mapping.  Currently this implements only the most common channel layouts for 2,4,6, and 8 channel output.  In practice the 5.1 and 7.1 channel layouts included here should cover the vast majority of use cases.  Further improvements could be possible adapting the changes from (https://github.com/osmc/vero3-linux/commit/fe80d3e75bbbbc08d1640df3cbe892962ffabf57#diff-691556440c8c18e0c564657393d18ba1)

In order not to conflict with analog output, a second tdm output is enabled in the device tree exclusively for hdmi usage.

Using it requires some changes to AML-AUGESOUND.conf.   (minimal is just changing device=1->device=3 for the default device, but this leaves the analog output inaccessible and results in incorrect naming of the devices.)