### PR TITLE
fix dithering behaviour for 10 bit video on 10 bit output

### DIFF
--- a/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hw/hdmi_tx_hw.c
+++ b/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hw/hdmi_tx_hw.c
@@ -2134,7 +2134,7 @@ void hdmitx_set_enc_hw(struct hdmitx_dev *hdev)
 		hd_set_reg_bits(P_VPU_HDMI_SETTING, 0, 4, 4);
 	}
 
-	switch (hdev->para->cd) {
+	switch (hdev->cur_video_param->color_depth) {
 	case COLORDEPTH_30B:
 	case COLORDEPTH_36B:
 	case COLORDEPTH_48B:


### PR DESCRIPTION
Currently the dithering behaviour intended for 8 bit output is used even for 10 bit output (ie 10bit->8 bit dithering is unnecessarily enabled), this restores the intended behaviour.

Note that 10 bit -> 8 bit dithering will still be enabled when playing back a 10 bit video on 8 bit output.