### PR TITLE
Dtbs fixes

### DIFF
--- a/arch/arm64/boot/dts/amlogic/Makefile
+++ b/arch/arm64/boot/dts/amlogic/Makefile
@@ -20,6 +20,7 @@ dtb-$(CONFIG_ARM64) += sm1_s905x3_4g.dtb
 dtb-$(CONFIG_ARM64) += sm1_s905x3_4g_1gbit.dtb
 dtb-$(CONFIG_ARM64) += sm1_s905x3_4g_1gbit_slowsdio.dtb
 dtb-$(CONFIG_ARM64) += sm1_s905x3_odroid_c4.dtb
+dtb-$(CONFIG_ARM64) += sm1_s905x3_odroid_c4_dvb.dtb
 
 always		:= $(dtb-y)
 subdir-y	:= $(dts-dirs)

--- a/arch/arm64/boot/dts/amlogic/g12b_a311d_khadas_vim3.dts
+++ b/arch/arm64/boot/dts/amlogic/g12b_a311d_khadas_vim3.dts
@@ -175,3 +175,18 @@
 &saradc {
 	status = "okay";
 };
+
+&spicc1 {
+	status = "disabled";
+	pinctrl-names = "default";
+	pinctrl-0 = <&spicc1_pins>;
+	cs-gpios = <&gpio GPIOH_6 GPIO_ACTIVE_HIGH>;
+
+	spidev@0 {
+		status = "disabled";
+		compatible = "linux,spidev";
+		/* spi default max clock 100Mhz */
+		spi-max-frequency = <100000000>;
+		reg = <0>;
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/g12b_s922x_odroid_n2.dts
+++ b/arch/arm64/boot/dts/amlogic/g12b_s922x_odroid_n2.dts
@@ -119,7 +119,6 @@
 	*/
 	pinctrl-names = "default","gpio_periphs";
 	pinctrl-0 = <&spicc0_pins_x>;
-	pinctrl-1 = <&spicc0_to_gpiox>;
 	num_chipselect = <2>;
 
 	cs-gpios = <&gpio GPIOX_10 GPIO_ACTIVE_LOW>,
@@ -166,22 +165,6 @@
 		mux {/* GPIOA_13 */
 			groups = "spdif_out_a13";
 			function = "spdif_out";
-		};
-	};
-
-	spicc0_pins_x: spicc0_pins_x {
-		mux {
-			drive-strength = <3>;
-		};
-	};
-
-	spicc0_to_gpiox: spicc0_gpiox {
-		mux {
-			groups = "GPIOX_8",
-				 "GPIOX_9",
-				 //"GPIOX_10",
-				 "GPIOX_11";
-			function = "gpio_periphs";
 		};
 	};
 };

--- a/arch/arm64/boot/dts/amlogic/sm1_s905d3_khadas_vim3l.dts
+++ b/arch/arm64/boot/dts/amlogic/sm1_s905d3_khadas_vim3l.dts
@@ -208,3 +208,18 @@
 &saradc {
 	status = "okay";
 };
+
+&spicc1 {
+	status = "disabled";
+	pinctrl-names = "default";
+	pinctrl-0 = <&spicc1_pins>;
+	cs-gpios = <&gpio GPIOH_6 GPIO_ACTIVE_HIGH>;
+
+	spidev@0 {
+		status = "disabled";
+		compatible = "linux,spidev";
+		/* spi default max clock 100Mhz */
+		spi-max-frequency = <100000000>;
+		reg = <0>;
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sm1_s905x3_odroid_c4.dts
+++ b/arch/arm64/boot/dts/amlogic/sm1_s905x3_odroid_c4.dts
@@ -71,7 +71,6 @@
 	*/
 	pinctrl-names = "default","gpio_periphs";
 	pinctrl-0 = <&spicc0_pins_x>;
-	pinctrl-1 = <&spicc0_to_gpiox>;
 	num_chipselect = <2>;
 
 	cs-gpios = <&gpio GPIOX_10 GPIO_ACTIVE_LOW>,
@@ -98,22 +97,6 @@
 &pinctrl_periphs {
 	/delete-node/ spdifout;
 	/delete-node/ spdifout_a_mute;
-
-	spicc0_pins_x: spicc0_pins_x {
-		mux {
-			drive-strength = <3>;
-		};
-	};
-
-	spicc0_to_gpiox: spicc0_gpiox {
-		mux {
-			groups = "GPIOX_8",
-				 "GPIOX_9",
-				 //"GPIOX_10",
-				 "GPIOX_11";
-			function = "gpio_periphs";
-		};
-	};
 };
 
 &pinctrl_aobus {

--- a/arch/arm64/boot/dts/amlogic/sm1_s905x3_odroid_c4.dts
+++ b/arch/arm64/boot/dts/amlogic/sm1_s905x3_odroid_c4.dts
@@ -167,3 +167,17 @@
 &uart_A {
 	status = "disabled";
 };
+
+&i2c2 {
+	status = "disabled";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c2_master_pins1>;
+	clock-frequency = <100000>;
+};
+
+&i2c3 {
+	status = "disabled";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c3_master_pins2>;
+	clock-frequency = <100000>;
+};

--- a/arch/arm64/boot/dts/amlogic/sm1_s905x3_odroid_c4_dvb.dts
+++ b/arch/arm64/boot/dts/amlogic/sm1_s905x3_odroid_c4_dvb.dts
@@ -1,0 +1,51 @@
+#include "sm1_s905x3_odroid_c4.dts"
+
+/{
+	coreelec-dt-id = "sm1_s905x3_odroid_c4_dvb";
+
+	dvb {
+		compatible = "amlogic,dvb";
+		dev_name = "avl6862";
+		status = "okay";
+		dtv_demod0_i2c_adap_id = <2>;
+		ts0 = "serial";
+		ts0_control = <0>;
+		ts0_invert = <0>;
+		fec_reset_gpio-gpios = <&gpio GPIOX_13 GPIO_ACTIVE_HIGH>;
+		power_ctrl_gpio-gpios = <&gpio GPIOX_12 GPIO_ACTIVE_LOW>;
+		pinctrl-names = "s_ts0", "s_ts1";
+		pinctrl-0 = <&dvb_s_ts0_pins>;
+		pinctrl-1 = <&dvb_s_ts1_pins>;
+		interrupts = <GIC_SPI 23 IRQ_TYPE_EDGE_RISING>,
+			     <GIC_SPI  5 IRQ_TYPE_EDGE_RISING>,
+			     <GIC_SPI 19 IRQ_TYPE_EDGE_RISING>,
+			     <GIC_SPI 25 IRQ_TYPE_EDGE_RISING>;
+		interrupt-names = "demux0", "demux1", "asyncfifo0", "asyncfifo1";
+	};
+};
+
+&pinctrl_periphs {
+	dvb_s_ts0_pins: dvb_s_ts0_pins {
+		tsin_a {
+			groups ="tsin_a_valid",
+				"tsin_a_sop",
+				"tsin_a_din0",
+				"tsin_a_clk";
+			function = "tsin_a";
+		};
+	};
+
+	dvb_s_ts1_pins: dvb_s_ts1_pins {
+		tsin_b {
+			groups = "tsin_b_sop_x",
+			"tsin_b_valid_x",
+			"tsin_b_clk_x",
+			"tsin_b_din0_x";
+			function = "tsin_b";
+		};
+	};
+};
+
+&i2c2 {
+	status = "okay";
+};


### PR DESCRIPTION
dts: add spicc1 for Khadas KVIM3/KVIM3L
dts: add i2c2 and i2c3 for Odroid C4
dts: add device tree for Odroid C4 with dvb 
dts: Odroid C4 and N2 SPI cleanup 

Tested only i2c2 on Odroid C4 with Khadas vTV board.