### PR TITLE
Revert 2 commits about FB scaling

### DIFF
--- a/drivers/amlogic/media/osd/osd_fb.c
+++ b/drivers/amlogic/media/osd/osd_fb.c
@@ -404,15 +404,6 @@ static int osd_set_fb_var(int index, const struct vinfo_s *vinfo)
 	return 0;
 }
 
-static void osd_set_fb_parameters(int index, const struct vinfo_s *vinfo)
-{
-	osd_set_free_scale_enable_hw(index, 0);
-	osd_set_free_scale_mode_hw(index, 1);
-	osd_set_free_scale_axis_hw(index, 0, 0, vinfo->width, vinfo->height);
-	osd_set_window_axis_hw(index, 0, 0, vinfo->width, vinfo->height);
-	osd_enable_hw(index, 1);
-}
-
 phys_addr_t get_fb_rmem_paddr(int index)
 {
 	if (index < 0 || index > 1)
@@ -4455,9 +4446,6 @@ static int osd_probe(struct platform_device *pdev)
 			for (i = 0; i < ARRAY_SIZE(osd_attrs_viu2); i++)
 			ret = device_create_file(fbi->dev, &osd_attrs_viu2[i]);
 		}
-
-		if (index == DEV_OSD0)
-			osd_set_fb_parameters(DEV_OSD0, vinfo);
 	}
 #ifdef CONFIG_AMLOGIC_LEGACY_EARLY_SUSPEND
 	early_suspend.level = EARLY_SUSPEND_LEVEL_STOP_DRAWING;

--- a/drivers/amlogic/media/osd/osd_fb.c
+++ b/drivers/amlogic/media/osd/osd_fb.c
@@ -388,22 +388,6 @@ struct ion_handle *fb_ion_handle[OSD_COUNT][OSD_MAX_BUF_NUM];
 
 static int osd_cursor(struct fb_info *fbi, struct fb_cursor *var);
 
-static int osd_set_fb_var(int index, const struct vinfo_s *vinfo)
-{
-	if ((vinfo->width < 0) || (vinfo->height < 0)) {
-		pr_err("invalid vinfo\n");
-		return 1;
-	}
-
-	fb_def_var[index].xres = vinfo->width;
-	fb_def_var[index].yres = vinfo->height;
-	fb_def_var[index].xres_virtual = vinfo->width;
-	fb_def_var[index].yres_virtual = vinfo->height * 2;
-	fb_def_var[index].bits_per_pixel = 32;
-
-	return 0;
-}
-
 phys_addr_t get_fb_rmem_paddr(int index)
 {
 	if (index < 0 || index > 1)
@@ -4375,28 +4359,16 @@ static int osd_probe(struct platform_device *pdev)
 			if (ret)
 				osd_log_info("not found display_size_default\n");
 			else {
-				if (osd_set_fb_var(index, vinfo)) {
-					/* no available vinfo, set default */
-					fb_def_var[index].xres =
-						var_screeninfo[0];
-					fb_def_var[index].yres =
-						var_screeninfo[1];
-					fb_def_var[index].xres_virtual =
-						var_screeninfo[2];
-					fb_def_var[index].yres_virtual =
-						var_screeninfo[3];
-					fb_def_var[index].bits_per_pixel =
-						var_screeninfo[4];
-				}
-				pr_info("fb def : %d %d %d %d %d\n",
-					fb_def_var[index].xres,
-					fb_def_var[index].yres,
-					fb_def_var[index].xres_virtual,
-					fb_def_var[index].yres_virtual,
+				fb_def_var[index].xres = var_screeninfo[0];
+				fb_def_var[index].yres = var_screeninfo[1];
+				fb_def_var[index].xres_virtual =
+					var_screeninfo[2];
+				fb_def_var[index].yres_virtual =
+					var_screeninfo[3];
+				fb_def_var[index].bits_per_pixel =
+					var_screeninfo[4];
+				osd_log_info("init fbdev bpp is:%d\n",
 					fb_def_var[index].bits_per_pixel);
-				pr_info("init fbdev bpp is:%d\n",
-					fb_def_var[index].bits_per_pixel);
-
 				if (fb_def_var[index].bits_per_pixel > 32)
 					fb_def_var[index].bits_per_pixel = 32;
 			}


### PR DESCRIPTION
These 2 commits are causing all kinds of issues especially with gxl where it breaks booting completly when using a scaled 4K GUI.