### PR TITLE
disable cts pin bias for uart used for BT

### DIFF
--- a/arch/arm64/boot/dts/amlogic/coreelec_g12b.dtsi
+++ b/arch/arm64/boot/dts/amlogic/coreelec_g12b.dtsi
@@ -15,3 +15,17 @@
 	mc_val = <0x1621>;
 	internal_phy=<0>;
 };
+
+&pinctrl_periphs {
+	a_uart_pins:a_uart {
+		mux {
+			groups = "uart_tx_a",
+				"uart_rx_a",
+				"uart_cts_a",
+				"uart_rts_a";
+			function = "uart_a";
+		};
+
+		/delete-node/ mux1;
+	};
+};


### PR DESCRIPTION
fixes uploading firmware to bcm43xx with the following error:
```
$ hciattach -n -s 115200 /dev/ttyS1 bcm43xx 2000000
hciattach Failed to reset chip, command failure
hciattach Can't initialize device: Success
```