### PR TITLE
dts: fix double gpio usage for Khadas KVIM3/KVIM3L

### DIFF
--- a/arch/arm64/boot/dts/amlogic/g12b_a311d_khadas_vim3.dts
+++ b/arch/arm64/boot/dts/amlogic/g12b_a311d_khadas_vim3.dts
@@ -66,6 +66,10 @@
 	};
 
 	/delete-node/ rtc;
+
+	auge_sound {
+		/delete-property/ avout_mute-gpios;
+	};
 };
 
 &audiobus {

--- a/arch/arm64/boot/dts/amlogic/sm1_s905d3_khadas_vim3l.dts
+++ b/arch/arm64/boot/dts/amlogic/sm1_s905d3_khadas_vim3l.dts
@@ -66,6 +66,10 @@
 	};
 
 	/delete-node/ rtc;
+
+	auge_sound {
+		/delete-property/ avout_mute-gpios;
+	};
 };
 
 &audiobus {


### PR DESCRIPTION
fixes
```
Jul 20 16:06:53 CoreELEC kernel: ff805000.i2c is using the pin GPIOAO_2 as pinmux
Jul 20 16:06:53 CoreELEC kernel: meson-g12a-pinctrl pinctrl@ff800014: request() failed for pin 2
Jul 20 16:06:53 CoreELEC kernel: meson-g12a-pinctrl pinctrl@ff800014: pin-2 (aobus-banks:498) status -22
```