### PR TITLE
Fix Minix NEO U22-XJ Gb ethernet

### DIFF
--- a/arch/arm64/boot/dts/amlogic/g12b_s922x_minix_u22xj.dts
+++ b/arch/arm64/boot/dts/amlogic/g12b_s922x_minix_u22xj.dts
@@ -109,6 +109,13 @@
 	};
 };
 
+&ethmac {
+	mc_val = <0x1629>;
+	cali_val = <0x10000>;
+	rx_delay = <0>;
+	auto_cali_idx = <0>;
+};
+
 &usb3_phy_v2 {
 	gpio-vbus-power = "GPIOH_5";
 	gpios = <&gpio GPIOH_5 GPIO_ACTIVE_HIGH>;


### PR DESCRIPTION
Gb ethernet was not working on Minix u22xj.  Using the Minix u22xj max dtb, Gb ethernet works.  I took the following lines from the dts for the Minix u22xj max and added them to the Minix u22xj dts and Gb the ethernet worked.