### PR TITLE
stmmac: add arguments so jl2xx1 can be loaded

### DIFF
--- a/drivers/net/ethernet/stmicro/stmmac/Kconfig
+++ b/drivers/net/ethernet/stmicro/stmmac/Kconfig
@@ -29,6 +29,16 @@ config STMMAC_PLATFORM
 
 if STMMAC_PLATFORM
 
+config STMMAC_JL2XX1
+	bool "Allow STMMAC delay for JL2XX1/JL2101 Gigabit Ethernet PHY"
+	default n
+	depends on STMMAC_PLATFORM
+	---help---
+	  This allows the STMMAC driver to be delayed for 1.5 seconds
+	  if the PHY JL2XX1/JL2101 is found so they can be properly
+	  initialized. This is only applied to the specific PHY IDs
+	  so other PHY won't be affected.
+
 config DWMAC_GENERIC
 	tristate "Generic driver for DWMAC"
 	default STMMAC_PLATFORM

--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
@@ -136,6 +136,12 @@ static void stmmac_exit_fs(struct net_device *dev);
 #define TX_MONITOR
 #endif
 
+/* PHY ID for JL2XX1 and JL2101, these are used for special initialization modifications for them */
+#ifdef CONFIG_STMMAC_JL2XX1
+#define JL2XX1_PHY_ID	0x937c4030
+#define JL2101_PHY_ID	0x937c4032
+#endif
+
 #ifdef TX_MONITOR
 static struct workqueue_struct *moniter_tx_wq;
 static struct delayed_work moniter_tx_worker;
@@ -1657,6 +1663,11 @@ static int stmmac_init_dma_engine(struct stmmac_priv *priv)
 
 	if (priv->extend_desc && (priv->mode == STMMAC_RING_MODE))
 		atds = 1;
+
+#ifdef CONFIG_STMMAC_JL2XX1
+	if (priv->phydev->phy_id == JL2XX1_PHY_ID || priv->phydev->phy_id == JL2101_PHY_ID)
+		msleep(1500);
+#endif
 
 	ret = priv->hw->dma->reset(priv->ioaddr);
 	if (ret) {


### PR DESCRIPTION
Different from my [previous PR](https://github.com/CoreELEC/linux-amlogic/pull/12) which also tries to bring JL2101 PHY support to the kernel. This only implements essential modification in the stmmac driver, and does not port the JL2XX1 driver, instead it uses the generic driver the JL2101. It also keeps the modifications behind some arguments so other devices won't be affected

This adds two new arguments ``jl2xx1_delay`` and ``jl2xx1_inject`` to the stmmac driver which can be set through kernel command line, which is then enabled at compilation time through config ``CONFIG_STMMAC_JL2XX1``. It's better to do it here in the kernel instead of splitting to another kmodule like stmmac_jl since stmmac is already set to built-in and can't be unloaded and replaced by another kmodule to be loaded in userspace. Also, by the time stmmac is up and running and recognizes the PHY id it is already impossible to do the early-stage modifications these two arguments do:
 - ``stmmac.jl2xx_delay``, it accepts unsigned interger value, in millesecond. If affects the delay before DMA engine is initialized, so JL2XX1 can be successfully identified.
   - Default: 0, for skipping the delay entirely
   - Suggested: 1500, for waiting 1.5 second
 - ``stmmac.jl2xx1_inject``, it accepts unsigned integer value, treated as bool. If affects whether or not to write specific code through MDIO before MII bus is initialized, so JL2XX1 can be successfully initialized.
    - Default: 0, for dont't inject
    - Suggested: 1, for inject

The PHY will be driven by the Generic PHY driver instead of the official JL2XX1 driver, this affects less things in the kernel and we don't need to modify the driver upon updates.

The PHY is stressed in a 12hour continous full-speed Tx+Rx iperf3 test, and capped at 720M Tx + 720M Rx when doing dual-direction, and 960M Tx or 960M Rx when doing single-direction, and stayed at an acceptable temp and has an ignorable drop rate during the test.

For end user, the JL2101 support can be enabled through adding ``stmmac.jl2xx1_delay=1500 stmmac.jl2xx1_inject=1`` in the kernel command line. This can either be done with uncommenting the coreelec line in the ``config.ini`` and adding it in there, or adding a switch option like ``jl2xx1`` in ``config.ini`` and setting these arguments in ``cfgload`` if it's set to true.