### PR TITLE
bluetooth: add support for TP-Link UB5A adapter

### DIFF
--- a/drivers/bluetooth/btusb.c
+++ b/drivers/bluetooth/btusb.c
@@ -365,6 +365,9 @@ static const struct usb_device_id blacklist_table[] = {
 	/* Additional Realtek 8822CE Bluetooth devices */
 	{ USB_DEVICE(0x04ca, 0x4005), .driver_info = BTUSB_REALTEK },
 
+	/* Tp-Link UB5A */
+	{ USB_DEVICE(0x2357, 0x0604), .driver_info = BTUSB_REALTEK },
+
 	/* Silicon Wave based devices */
 	{ USB_DEVICE(0x0c10, 0x0000), .driver_info = BTUSB_SWAVE },
 


### PR DESCRIPTION
Adds support for TP-Link UB500/UB5A BT 5.0 adapters 

Tested on CE/EE with Xbox One S Joypad

Commit adapted from https://lore.kernel.org/lkml/20211119171443.986541312@linuxfoundation.org/