### PR TITLE
fix sm1_s905_4g logo_addr

### DIFF
--- a/arch/arm64/boot/dts/amlogic/sm1_s905x3_4g.dts
+++ b/arch/arm64/boot/dts/amlogic/sm1_s905x3_4g.dts
@@ -5,5 +5,16 @@
 
 	memory@00000000 {
 		linux,usable-memory = <0x0 0x100000 0x0 0xf0800000>;
+		/* 0xf5700000 used in stock android dtb changed
+		to 0xf0800000 to fix some 4G generic devices 
+		not able to boot with the default value.*/
 	};
+};
+
+&logo_reserved {
+	alloc-ranges = <0x0 0xdf800000 0x0 0x800000>;
+};
+
+&meson_fb {
+	logo_addr = "0xdf800000";
 };


### PR DESCRIPTION
Restored value as per stock android boot.img dtb (sm1_ac213_4g).
Previous value `0xf0800000` caused junk data to screen after boot (ref. [here](https://discourse.coreelec.org/t/coreelec-20-0-nexus-alpha2-discussion/18860/32)).