### PR TITLE
deinterlace: disable debug message, hdmitx: disable debug message

### DIFF
--- a/drivers/amlogic/media/di_multi/deinterlace.c
+++ b/drivers/amlogic/media/di_multi/deinterlace.c
@@ -7124,7 +7124,7 @@ void dim_irq_pre(void)
 			flag = 0;
 		}
 	} else {
-		PR_WARN("irq:flag 0\n");
+		//PR_WARN("irq:flag 0\n");
 	}
 
 	/* check timeout*/

--- a/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hdmi_tx_main.c
+++ b/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hdmi_tx_main.c
@@ -1826,7 +1826,7 @@ static void hdr_work_func(struct work_struct *work)
 		unsigned char DRM_HB[3] = {0x87, 0x1, 26};
 		unsigned char DRM_DB[26] = {0x0};
 
-		pr_info("%s: send zero DRM\n", __func__);
+		//pr_info("%s: send zero DRM\n", __func__);
 		hdev->hwop.setpacket(HDMI_PACKET_DRM, DRM_DB, DRM_HB);
 
 		msleep(1500);/*delay 1.5s*/

--- a/drivers/amlogic/media/vout/hdmitx21/hdmi_tx_main.c
+++ b/drivers/amlogic/media/vout/hdmitx21/hdmi_tx_main.c
@@ -1719,7 +1719,7 @@ static void hdr_work_func(struct work_struct *work)
 
 	if (hdev->hdr_transfer_feature == T_BT709 &&
 	    hdev->hdr_color_feature == C_BT709) {
-		pr_info("%s: send zero DRM\n", __func__);
+		//pr_info("%s: send zero DRM\n", __func__);
 		hdmi_drm_infoframe_init(info);
 		hdmi_drm_infoframe_set(info);
 		hdmi_avi_infoframe_config(CONF_AVI_BT2020, hdev->colormetry);


### PR DESCRIPTION
There are several debug messages flooding syslog. The patch attached disables these messages.