### PR TITLE
DT: Update mesong12b to improve S922X device perofrmance

### DIFF
--- a/arch/arm64/boot/dts/amlogic/coreelec_g12b.dtsi
+++ b/arch/arm64/boot/dts/amlogic/coreelec_g12b.dtsi
@@ -1,5 +1,6 @@
 #include "g12b_a311d_w400.dts"
 #include "coreelec_g12_common.dtsi"
+#include "coreelec_g12b_cache.dtsi"
 
 /{
 	reserved-memory {

--- a/arch/arm64/boot/dts/amlogic/coreelec_g12b_a.dtsi
+++ b/arch/arm64/boot/dts/amlogic/coreelec_g12b_a.dtsi
@@ -1,5 +1,6 @@
 #include "g12b_a311d_w400_a.dts"
 #include "coreelec_g12_common.dtsi"
+#include "coreelec_g12b_cache.dtsi"
 
 /{
 	reserved-memory {

--- a/arch/arm64/boot/dts/amlogic/coreelec_g12b_cache.dtsi
+++ b/arch/arm64/boot/dts/amlogic/coreelec_g12b_cache.dtsi
@@ -1,0 +1,175 @@
+
+/ {
+	cpus:cpus {
+		#address-cells = <2>;
+		#size-cells = <0>;
+
+		cpu-map {
+			cluster0:cluster0 {
+				core0 {
+					cpu = <&CPU0>;
+				};
+				core1 {
+					cpu = <&CPU1>;
+				};
+			};
+			cluster1:cluster1 {
+				core0 {
+					cpu = <&CPU2>;
+				};
+				core1 {
+					cpu = <&CPU3>;
+				};
+				core2 {
+					cpu = <&CPU4>;
+				};
+				core3 {
+					cpu = <&CPU5>;
+				};
+			};
+		};
+
+		CPU0:cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a53","arm,armv8";
+			reg = <0x0 0x0>;
+			enable-method = "psci";
+			//cpu-idle-states = <&CPU_SLEEP_0 &CLUSTER_SLEEP_0>;
+			capacity-dmips-mhz = <778>;
+			sched-energy-costs = <&CPU_COST_A53 &CLUSTER_COST_A53>;
+			clocks = <&clkc CLKID_CPU_CLK>,
+				<&clkc CLKID_CPU_FCLK_P>,
+				<&clkc CLKID_SYS1_PLL>;
+			clock-names = "core_clk",
+				"low_freq_clk_parent",
+				"high_freq_clk_parent";
+			operating-points-v2 = <&cpu_opp_table0>;
+			cpu-supply = <&vddcpu0>;
+			voltage-tolerance = <0>;
+			clock-latency = <50000>;
+			next-level-cache = <&l2_0>;
+		};
+
+		CPU1:cpu@1 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a53","arm,armv8";
+			reg = <0x0 0x1>;
+			enable-method = "psci";
+			capacity-dmips-mhz = <778>;
+			sched-energy-costs = <&CPU_COST_A53 &CLUSTER_COST_A53>;
+			clocks = <&clkc CLKID_CPU_CLK>,
+			       <&clkc CLKID_CPU_FCLK_P>,
+			       <&clkc CLKID_SYS1_PLL>;
+			clock-names = "core_clk",
+				"low_freq_clk_parent",
+				"high_freq_clk_parent";
+			operating-points-v2 = <&cpu_opp_table0>;
+			cpu-supply = <&vddcpu0>;
+			voltage-tolerance = <0>;
+			clock-latency = <50000>;
+			next-level-cache = <&l2_0>;
+		};
+
+		CPU2:cpu@100 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a73","arm,armv8";
+			reg = <0x0 0x100>;
+			enable-method = "psci";
+			//cpu-idle-states = <&CPU_SLEEP_0 &CLUSTER_SLEEP_0>;
+			sched-energy-costs = <&CPU_COST_A73 &CLUSTER_COST_A73>;
+			capacity-dmips-mhz = <1192>;
+			clocks = <&clkc CLKID_CPUB_CLK>,
+				<&clkc CLKID_CPUB_FCLK_P>,
+				<&clkc CLKID_SYS_PLL>;
+			clock-names = "core_clk",
+				"low_freq_clk_parent",
+				"high_freq_clk_parent";
+			operating-points-v2 = <&cpu_opp_table1>;
+			cpu-supply = <&vddcpu1>;
+			voltage-tolerance = <0>;
+			clock-latency = <50000>;
+			next-level-cache = <&l2_1>;
+		};
+
+		CPU3:cpu@101 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a73","arm,armv8";
+			reg = <0x0 0x101>;
+			enable-method = "psci";
+			//cpu-idle-states = <&CPU_SLEEP_0 &CLUSTER_SLEEP_0>;
+			sched-energy-costs = <&CPU_COST_A73 &CLUSTER_COST_A73>;
+			capacity-dmips-mhz = <1192>;
+			clocks = <&clkc CLKID_CPUB_CLK>,
+			       <&clkc CLKID_CPUB_FCLK_P>,
+			       <&clkc CLKID_SYS_PLL>;
+			clock-names = "core_clk",
+				"low_freq_clk_parent",
+				"high_freq_clk_parent";
+			operating-points-v2 = <&cpu_opp_table1>;
+			cpu-supply = <&vddcpu1>;
+			voltage-tolerance = <0>;
+			clock-latency = <50000>;
+			next-level-cache = <&l2_1>;
+		};
+
+		CPU4:cpu@102 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a73","arm,armv8";
+			reg = <0x0 0x102>;
+			enable-method = "psci";
+			//cpu-idle-states = <&CPU_SLEEP_0 &CLUSTER_SLEEP_0>;
+			sched-energy-costs = <&CPU_COST_A73 &CLUSTER_COST_A73>;
+			capacity-dmips-mhz = <1192>;
+			clocks = <&clkc CLKID_CPUB_CLK>,
+			       <&clkc CLKID_CPUB_FCLK_P>,
+			       <&clkc CLKID_SYS_PLL>;
+			clock-names = "core_clk",
+				"low_freq_clk_parent",
+				"high_freq_clk_parent";
+			operating-points-v2 = <&cpu_opp_table1>;
+			cpu-supply = <&vddcpu1>;
+			voltage-tolerance = <0>;
+			clock-latency = <50000>;
+			next-level-cache = <&l2_1>;
+		};
+
+		CPU5:cpu@103 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a73","arm,armv8";
+			reg = <0x0 0x103>;
+			enable-method = "psci";
+			//cpu-idle-states = <&CPU_SLEEP_0 &CLUSTER_SLEEP_0>;
+			sched-energy-costs = <&CPU_COST_A73 &CLUSTER_COST_A73>;
+			capacity-dmips-mhz = <1192>;
+			clocks = <&clkc CLKID_CPUB_CLK>,
+			       <&clkc CLKID_CPUB_FCLK_P>,
+			       <&clkc CLKID_SYS_PLL>;
+			clock-names = "core_clk",
+				"low_freq_clk_parent",
+				"high_freq_clk_parent";
+			operating-points-v2 = <&cpu_opp_table1>;
+			cpu-supply = <&vddcpu1>;
+			voltage-tolerance = <0>;
+			clock-latency = <50000>;
+			next-level-cache = <&l2_1>;
+		};
+		
+		l2_0: l2-cache0 {
+ 			compatible = "cache";
+			cache-level = <2>;
+			cache-unified;
+			cache-size = <0x80000>;
+			cache-line-size = <64>;
+			cache-sets = <512>;
+ 		};
+ 		
+ 		l2_1: l2-cache1 {
+ 			compatible = "cache";
+			cache-level = <2>;
+			cache-unified;
+			cache-size = <0x100000>;
+			cache-line-size = <64>;
+			cache-sets = <1024>;
+		};
+ 	}
+ }

--- a/arch/arm64/boot/dts/amlogic/coreelec_g12b_cache.dtsi
+++ b/arch/arm64/boot/dts/amlogic/coreelec_g12b_cache.dtsi
@@ -1,0 +1,176 @@
+
+/ {
+	cpus:cpus {
+		#address-cells = <2>;
+		#size-cells = <0>;
+
+		cpu-map {
+			cluster0:cluster0 {
+				core0 {
+					cpu = <&CPU0>;
+				};
+				core1 {
+					cpu = <&CPU1>;
+				};
+			};
+			cluster1:cluster1 {
+				core0 {
+					cpu = <&CPU2>;
+				};
+				core1 {
+					cpu = <&CPU3>;
+				};
+				core2 {
+					cpu = <&CPU4>;
+				};
+				core3 {
+					cpu = <&CPU5>;
+				};
+			};
+		};
+
+		CPU0:cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a53","arm,armv8";
+			reg = <0x0 0x0>;
+			enable-method = "psci";
+			//cpu-idle-states = <&CPU_SLEEP_0 &CLUSTER_SLEEP_0>;
+			capacity-dmips-mhz = <778>;
+			sched-energy-costs = <&CPU_COST_A53 &CLUSTER_COST_A53>;
+			clocks = <&clkc CLKID_CPU_CLK>,
+				<&clkc CLKID_CPU_FCLK_P>,
+				<&clkc CLKID_SYS1_PLL>;
+			clock-names = "core_clk",
+				"low_freq_clk_parent",
+				"high_freq_clk_parent";
+			operating-points-v2 = <&cpu_opp_table0>;
+			cpu-supply = <&vddcpu0>;
+			voltage-tolerance = <0>;
+			clock-latency = <50000>;
+			next-level-cache = <&l2_0>;
+		};
+
+		CPU1:cpu@1 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a53","arm,armv8";
+			reg = <0x0 0x1>;
+			enable-method = "psci";
+			capacity-dmips-mhz = <778>;
+			sched-energy-costs = <&CPU_COST_A53 &CLUSTER_COST_A53>;
+			clocks = <&clkc CLKID_CPU_CLK>,
+			       <&clkc CLKID_CPU_FCLK_P>,
+			       <&clkc CLKID_SYS1_PLL>;
+			clock-names = "core_clk",
+				"low_freq_clk_parent",
+				"high_freq_clk_parent";
+			operating-points-v2 = <&cpu_opp_table0>;
+			cpu-supply = <&vddcpu0>;
+			voltage-tolerance = <0>;
+			clock-latency = <50000>;
+			next-level-cache = <&l2_0>;
+		};
+
+		CPU2:cpu@100 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a73","arm,armv8";
+			reg = <0x0 0x100>;
+			enable-method = "psci";
+			//cpu-idle-states = <&CPU_SLEEP_0 &CLUSTER_SLEEP_0>;
+			sched-energy-costs = <&CPU_COST_A73 &CLUSTER_COST_A73>;
+			capacity-dmips-mhz = <1192>;
+			clocks = <&clkc CLKID_CPUB_CLK>,
+				<&clkc CLKID_CPUB_FCLK_P>,
+				<&clkc CLKID_SYS_PLL>;
+			clock-names = "core_clk",
+				"low_freq_clk_parent",
+				"high_freq_clk_parent";
+			operating-points-v2 = <&cpu_opp_table1>;
+			cpu-supply = <&vddcpu1>;
+			voltage-tolerance = <0>;
+			clock-latency = <50000>;
+			next-level-cache = <&l2_1>;
+		};
+
+		CPU3:cpu@101 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a73","arm,armv8";
+			reg = <0x0 0x101>;
+			enable-method = "psci";
+			//cpu-idle-states = <&CPU_SLEEP_0 &CLUSTER_SLEEP_0>;
+			sched-energy-costs = <&CPU_COST_A73 &CLUSTER_COST_A73>;
+			capacity-dmips-mhz = <1192>;
+			clocks = <&clkc CLKID_CPUB_CLK>,
+			       <&clkc CLKID_CPUB_FCLK_P>,
+			       <&clkc CLKID_SYS_PLL>;
+			clock-names = "core_clk",
+				"low_freq_clk_parent",
+				"high_freq_clk_parent";
+			operating-points-v2 = <&cpu_opp_table1>;
+			cpu-supply = <&vddcpu1>;
+			voltage-tolerance = <0>;
+			clock-latency = <50000>;
+			next-level-cache = <&l2_1>;
+		};
+
+		CPU4:cpu@102 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a73","arm,armv8";
+			reg = <0x0 0x102>;
+			enable-method = "psci";
+			//cpu-idle-states = <&CPU_SLEEP_0 &CLUSTER_SLEEP_0>;
+			sched-energy-costs = <&CPU_COST_A73 &CLUSTER_COST_A73>;
+			capacity-dmips-mhz = <1192>;
+			clocks = <&clkc CLKID_CPUB_CLK>,
+			       <&clkc CLKID_CPUB_FCLK_P>,
+			       <&clkc CLKID_SYS_PLL>;
+			clock-names = "core_clk",
+				"low_freq_clk_parent",
+				"high_freq_clk_parent";
+			operating-points-v2 = <&cpu_opp_table1>;
+			cpu-supply = <&vddcpu1>;
+			voltage-tolerance = <0>;
+			clock-latency = <50000>;
+			next-level-cache = <&l2_1>;
+		};
+
+		CPU5:cpu@103 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a73","arm,armv8";
+			reg = <0x0 0x103>;
+			enable-method = "psci";
+			//cpu-idle-states = <&CPU_SLEEP_0 &CLUSTER_SLEEP_0>;
+			sched-energy-costs = <&CPU_COST_A73 &CLUSTER_COST_A73>;
+			capacity-dmips-mhz = <1192>;
+			clocks = <&clkc CLKID_CPUB_CLK>,
+			       <&clkc CLKID_CPUB_FCLK_P>,
+			       <&clkc CLKID_SYS_PLL>;
+			clock-names = "core_clk",
+				"low_freq_clk_parent",
+				"high_freq_clk_parent";
+			operating-points-v2 = <&cpu_opp_table1>;
+			cpu-supply = <&vddcpu1>;
+			voltage-tolerance = <0>;
+			clock-latency = <50000>;
+			next-level-cache = <&l2_1>;
+		};
+
+		//HINT:cache-size does not have to be correct, just get the hierarchy right. 
+		l2_0: l2-cache0 {
+ 			compatible = "cache";
+			cache-level = <2>;
+			cache-unified;
+			cache-size = <0x80000>;
+			cache-line-size = <64>;
+			cache-sets = <512>;
+ 		};
+ 		
+ 		l2_1: l2-cache1 {
+ 			compatible = "cache";
+			cache-level = <2>;
+			cache-unified;
+			cache-size = <0x100000>;
+			cache-line-size = <64>;
+			cache-sets = <1024>;
+		};
+ 	}
+ }

--- a/arch/arm64/boot/dts/amlogic/coreelec_g12b_cache.dtsi
+++ b/arch/arm64/boot/dts/amlogic/coreelec_g12b_cache.dtsi
@@ -153,7 +153,8 @@
 			clock-latency = <50000>;
 			next-level-cache = <&l2_1>;
 		};
-		
+
+		//HINT:cache-size does not have to be correct, just get the hierarchy right. 
 		l2_0: l2-cache0 {
  			compatible = "cache";
 			cache-level = <2>;

--- a/arch/arm64/boot/dts/amlogic/mesong12b.dtsi
+++ b/arch/arm64/boot/dts/amlogic/mesong12b.dtsi
@@ -66,6 +66,7 @@
 			reg = <0x0 0x0>;
 			enable-method = "psci";
 			//cpu-idle-states = <&CPU_SLEEP_0 &CLUSTER_SLEEP_0>;
+			capacity-dmips-mhz = <778>;
 			sched-energy-costs = <&CPU_COST_A53 &CLUSTER_COST_A53>;
 			clocks = <&clkc CLKID_CPU_CLK>,
 				<&clkc CLKID_CPU_FCLK_P>,
@@ -77,6 +78,7 @@
 			cpu-supply = <&vddcpu0>;
 			voltage-tolerance = <0>;
 			clock-latency = <50000>;
+			next-level-cache = <&l2_0>;
 		};
 
 		CPU1:cpu@1 {
@@ -84,6 +86,7 @@
 			compatible = "arm,cortex-a53","arm,armv8";
 			reg = <0x0 0x1>;
 			enable-method = "psci";
+			capacity-dmips-mhz = <778>;
 			sched-energy-costs = <&CPU_COST_A53 &CLUSTER_COST_A53>;
 			clocks = <&clkc CLKID_CPU_CLK>,
 			       <&clkc CLKID_CPU_FCLK_P>,
@@ -95,6 +98,7 @@
 			cpu-supply = <&vddcpu0>;
 			voltage-tolerance = <0>;
 			clock-latency = <50000>;
+			next-level-cache = <&l2_0>;
 		};
 
 		CPU2:cpu@100 {
@@ -104,6 +108,7 @@
 			enable-method = "psci";
 			//cpu-idle-states = <&CPU_SLEEP_0 &CLUSTER_SLEEP_0>;
 			sched-energy-costs = <&CPU_COST_A73 &CLUSTER_COST_A73>;
+			capacity-dmips-mhz = <1192>;
 			clocks = <&clkc CLKID_CPUB_CLK>,
 				<&clkc CLKID_CPUB_FCLK_P>,
 				<&clkc CLKID_SYS_PLL>;
@@ -114,6 +119,7 @@
 			cpu-supply = <&vddcpu1>;
 			voltage-tolerance = <0>;
 			clock-latency = <50000>;
+			next-level-cache = <&l2_1>;
 		};
 
 		CPU3:cpu@101 {
@@ -123,6 +129,7 @@
 			enable-method = "psci";
 			//cpu-idle-states = <&CPU_SLEEP_0 &CLUSTER_SLEEP_0>;
 			sched-energy-costs = <&CPU_COST_A73 &CLUSTER_COST_A73>;
+			capacity-dmips-mhz = <1192>;
 			clocks = <&clkc CLKID_CPUB_CLK>,
 			       <&clkc CLKID_CPUB_FCLK_P>,
 			       <&clkc CLKID_SYS_PLL>;
@@ -133,6 +140,7 @@
 			cpu-supply = <&vddcpu1>;
 			voltage-tolerance = <0>;
 			clock-latency = <50000>;
+			next-level-cache = <&l2_1>;
 		};
 
 		CPU4:cpu@102 {
@@ -142,6 +150,7 @@
 			enable-method = "psci";
 			//cpu-idle-states = <&CPU_SLEEP_0 &CLUSTER_SLEEP_0>;
 			sched-energy-costs = <&CPU_COST_A73 &CLUSTER_COST_A73>;
+			capacity-dmips-mhz = <1192>;
 			clocks = <&clkc CLKID_CPUB_CLK>,
 			       <&clkc CLKID_CPUB_FCLK_P>,
 			       <&clkc CLKID_SYS_PLL>;
@@ -152,6 +161,7 @@
 			cpu-supply = <&vddcpu1>;
 			voltage-tolerance = <0>;
 			clock-latency = <50000>;
+			next-level-cache = <&l2_1>;
 		};
 
 		CPU5:cpu@103 {
@@ -161,6 +171,7 @@
 			enable-method = "psci";
 			//cpu-idle-states = <&CPU_SLEEP_0 &CLUSTER_SLEEP_0>;
 			sched-energy-costs = <&CPU_COST_A73 &CLUSTER_COST_A73>;
+			capacity-dmips-mhz = <1192>;
 			clocks = <&clkc CLKID_CPUB_CLK>,
 			       <&clkc CLKID_CPUB_FCLK_P>,
 			       <&clkc CLKID_SYS_PLL>;
@@ -171,7 +182,26 @@
 			cpu-supply = <&vddcpu1>;
 			voltage-tolerance = <0>;
 			clock-latency = <50000>;
+			next-level-cache = <&l2_1>;
 		};
+		// the cache size values do not have to be 100% correct, we only need correct hierarchy
+		l2_0: l2-cache0 {
+ 			compatible = "cache";
+			cache-level = <2>;
+			cache-unified;
+			cache-size = <0x80000>;
+			cache-line-size = <64>;
+			cache-sets = <512>;
+ 		};
+ 		
+ 		l2_1: l2-cache1 {
+ 			compatible = "cache";
+			cache-level = <2>;
+			cache-unified;
+			cache-size = <0x100000>;
+			cache-line-size = <64>;
+			cache-sets = <1024>;
+ 		};
 
 		idle-states {
 			entry-method = "arm,psci";

--- a/arch/arm64/boot/dts/amlogic/mesong12b.dtsi
+++ b/arch/arm64/boot/dts/amlogic/mesong12b.dtsi
@@ -66,7 +66,6 @@
 			reg = <0x0 0x0>;
 			enable-method = "psci";
 			//cpu-idle-states = <&CPU_SLEEP_0 &CLUSTER_SLEEP_0>;
-			capacity-dmips-mhz = <778>;
 			sched-energy-costs = <&CPU_COST_A53 &CLUSTER_COST_A53>;
 			clocks = <&clkc CLKID_CPU_CLK>,
 				<&clkc CLKID_CPU_FCLK_P>,
@@ -78,7 +77,6 @@
 			cpu-supply = <&vddcpu0>;
 			voltage-tolerance = <0>;
 			clock-latency = <50000>;
-			next-level-cache = <&l2_0>;
 		};
 
 		CPU1:cpu@1 {
@@ -86,7 +84,6 @@
 			compatible = "arm,cortex-a53","arm,armv8";
 			reg = <0x0 0x1>;
 			enable-method = "psci";
-			capacity-dmips-mhz = <778>;
 			sched-energy-costs = <&CPU_COST_A53 &CLUSTER_COST_A53>;
 			clocks = <&clkc CLKID_CPU_CLK>,
 			       <&clkc CLKID_CPU_FCLK_P>,
@@ -98,7 +95,6 @@
 			cpu-supply = <&vddcpu0>;
 			voltage-tolerance = <0>;
 			clock-latency = <50000>;
-			next-level-cache = <&l2_0>;
 		};
 
 		CPU2:cpu@100 {
@@ -108,7 +104,6 @@
 			enable-method = "psci";
 			//cpu-idle-states = <&CPU_SLEEP_0 &CLUSTER_SLEEP_0>;
 			sched-energy-costs = <&CPU_COST_A73 &CLUSTER_COST_A73>;
-			capacity-dmips-mhz = <1192>;
 			clocks = <&clkc CLKID_CPUB_CLK>,
 				<&clkc CLKID_CPUB_FCLK_P>,
 				<&clkc CLKID_SYS_PLL>;
@@ -119,7 +114,6 @@
 			cpu-supply = <&vddcpu1>;
 			voltage-tolerance = <0>;
 			clock-latency = <50000>;
-			next-level-cache = <&l2_1>;
 		};
 
 		CPU3:cpu@101 {
@@ -129,7 +123,6 @@
 			enable-method = "psci";
 			//cpu-idle-states = <&CPU_SLEEP_0 &CLUSTER_SLEEP_0>;
 			sched-energy-costs = <&CPU_COST_A73 &CLUSTER_COST_A73>;
-			capacity-dmips-mhz = <1192>;
 			clocks = <&clkc CLKID_CPUB_CLK>,
 			       <&clkc CLKID_CPUB_FCLK_P>,
 			       <&clkc CLKID_SYS_PLL>;
@@ -140,7 +133,6 @@
 			cpu-supply = <&vddcpu1>;
 			voltage-tolerance = <0>;
 			clock-latency = <50000>;
-			next-level-cache = <&l2_1>;
 		};
 
 		CPU4:cpu@102 {
@@ -150,7 +142,6 @@
 			enable-method = "psci";
 			//cpu-idle-states = <&CPU_SLEEP_0 &CLUSTER_SLEEP_0>;
 			sched-energy-costs = <&CPU_COST_A73 &CLUSTER_COST_A73>;
-			capacity-dmips-mhz = <1192>;
 			clocks = <&clkc CLKID_CPUB_CLK>,
 			       <&clkc CLKID_CPUB_FCLK_P>,
 			       <&clkc CLKID_SYS_PLL>;
@@ -161,7 +152,6 @@
 			cpu-supply = <&vddcpu1>;
 			voltage-tolerance = <0>;
 			clock-latency = <50000>;
-			next-level-cache = <&l2_1>;
 		};
 
 		CPU5:cpu@103 {
@@ -171,7 +161,6 @@
 			enable-method = "psci";
 			//cpu-idle-states = <&CPU_SLEEP_0 &CLUSTER_SLEEP_0>;
 			sched-energy-costs = <&CPU_COST_A73 &CLUSTER_COST_A73>;
-			capacity-dmips-mhz = <1192>;
 			clocks = <&clkc CLKID_CPUB_CLK>,
 			       <&clkc CLKID_CPUB_FCLK_P>,
 			       <&clkc CLKID_SYS_PLL>;
@@ -182,26 +171,7 @@
 			cpu-supply = <&vddcpu1>;
 			voltage-tolerance = <0>;
 			clock-latency = <50000>;
-			next-level-cache = <&l2_1>;
 		};
-		// the cache size values do not have to be 100% correct, we only need correct hierarchy
-		l2_0: l2-cache0 {
- 			compatible = "cache";
-			cache-level = <2>;
-			cache-unified;
-			cache-size = <0x80000>;
-			cache-line-size = <64>;
-			cache-sets = <512>;
- 		};
- 		
- 		l2_1: l2-cache1 {
- 			compatible = "cache";
-			cache-level = <2>;
-			cache-unified;
-			cache-size = <0x100000>;
-			cache-line-size = <64>;
-			cache-sets = <1024>;
- 		};
 
 		idle-states {
 			entry-method = "arm,psci";


### PR DESCRIPTION
Add cpu cache hierarchy so that linux scheduler stops bumping processes between cores and we stop the latency penalty.
Add cpu dmips to inform the kernel that clusters are uneven.

Expecting performance improvements