### PR TITLE
cpuinfo: separate S6 SoC S905X5 and S905X5L

### DIFF
--- a/arch/arm64/kernel/cpuinfo.c
+++ b/arch/arm64/kernel/cpuinfo.c
@@ -33,6 +33,8 @@
 enum meson_cpu_pack_id_e {
 	MESON_CPU_PACK_ID_S7D_S905X5M = 0x01,
 	MESON_CPU_PACK_ID_S7D_S905A   = 0x03,
+	MESON_CPU_PACK_ID_S6_S905X5   = 0x01,
+	MESON_CPU_PACK_ID_S6_S905X5L  = 0x05,
 };
 
 /*
@@ -287,7 +289,17 @@ static int c_show(struct seq_file *m, void *v)
 			}
 			break;
 		case MESON_CPU_MAJOR_ID_S6:
-			seq_puts(m, "S905X5\n");
+			switch (chipid[MESON_CPU_VERSION_LVL_PACK]) {
+				case MESON_CPU_PACK_ID_S6_S905X5:
+					seq_puts(m, "S905X5\n");
+					break;
+				case MESON_CPU_PACK_ID_S6_S905X5L:
+					seq_puts(m, "S905X5L\n");
+					break;
+				default:
+					seq_puts(m, "S6 Unknown\n");
+					break;
+			}
 			break;
 		case MESON_CPU_MAJOR_ID_S7:
 			seq_puts(m, "S905Y5\n");


### PR DESCRIPTION
serial number:
```
S905X5:  480b0101000000000826410170f71d00   pack_id: 0x01
S905X5L: 480b0502000000001f1b414658c71d00   pack_id: 0x05
```