### PR TITLE
cpuinfo: separate s905x4 and s905c2l

### DIFF
--- a/arch/arm64/kernel/cpuinfo.c
+++ b/arch/arm64/kernel/cpuinfo.c
@@ -33,6 +33,8 @@
 enum meson_cpu_pack_id_e {
 	MESON_CPU_PACK_ID_S7D_S905X5M = 0x01,
 	MESON_CPU_PACK_ID_S7D_S905A   = 0x03,
+	MESON_CPU_PACK_ID_SC2_S905X4  = 0x02,
+	MESON_CPU_PACK_ID_SC2_S905C2L = 0x05,
 };
 
 /*
@@ -257,7 +259,17 @@ static int c_show(struct seq_file *m, void *v)
 			seq_puts(m, "SM1\n");
 			break;
 		case MESON_CPU_MAJOR_ID_SC2:
-			seq_puts(m, "S905X4\n");
+			switch (chipid[MESON_CPU_VERSION_LVL_PACK]) {
+			case MESON_CPU_PACK_ID_SC2_S905X4:
+				seq_puts(m, "S905X4\n");
+				break;
+			case MESON_CPU_PACK_ID_SC2_S905C2L:
+				seq_puts(m, "S905C2L\n");
+				break;
+			default:
+				seq_puts(m, "SC2 Unknown\n");
+				break;
+			}
 			break;
 		case MESON_CPU_MAJOR_ID_S5:
 			seq_puts(m, "S928X\n");


### PR DESCRIPTION
serial number:
  S905X4:  320a0204000000002a07604125e05900   pack_id: 0x02
  S905C2L: 320d0502000000002521400419105680   pack_id: 0x05