### PR TITLE
amdolby_vision: send the canonical LLDV signal (1) in the Dolby Vision VSIF

### DIFF
--- a/drivers/amlogic/media/enhancement/amdolby_vision/amdolby_vision.c
+++ b/drivers/amlogic/media/enhancement/amdolby_vision/amdolby_vision.c
@@ -227,6 +227,11 @@ MODULE_PARM_DESC(dv_ll_output_mode, "\n dv_ll_output_mode\n");
 static u32 dolby_vision_ll_policy = DOLBY_VISION_LL_DISABLE;
 module_param(dolby_vision_ll_policy, uint, 0664);
 MODULE_PARM_DESC(dolby_vision_ll_policy, "\n dolby_vision_ll_policy\n");
+
+/* Emit the canonical player-led Dolby Vision signal value for LLDV output. */
+static bool dolby_vision_canonical_ll_signal = true;
+module_param(dolby_vision_canonical_ll_signal, bool, 0664);
+MODULE_PARM_DESC(dolby_vision_canonical_ll_signal, "\n dolby_vision_canonical_ll_signal\n");
 static u32 last_dolby_vision_ll_policy = DOLBY_VISION_LL_DISABLE;
 
 #ifdef V2_4_3
@@ -7036,6 +7041,22 @@ static int prepare_vsif_pkt
 		vsif->vers.ver2.dobly_vision_signal = 7;/*0b0111*/
 	else if (src_format == FORMAT_SDR || src_format == FORMAT_SDR_2020)
 		vsif->vers.ver2.dobly_vision_signal = 5;/*0b0101*/
+
+	/*
+	 * The values above encode the pre-VS10 source type in bits that are
+	 * reserved in the player-led (low latency) Dolby Vision VSIF, so a
+	 * VS10 converted stream is signalled as 3, 5 or 7 instead of 1. Once
+	 * VS10 has converted the source the HDMI output is ordinary LLDV, and
+	 * sinks that validate the reserved bits reject the infoframe. Signal
+	 * the canonical value 1 whenever the output itself is LLDV; TV-led
+	 * Dolby Vision keeps the legacy encoding.
+	 *
+	 * The 5.15 Amlogic driver reached the same conclusion and disabled
+	 * the 3/5/7 encoding behind #define NEW_DOLBY_SIGNAL_TYPE 0.
+	 */
+	if (dolby_vision_canonical_ll_signal && setting->dovi_ll_enable)
+		vsif->vers.ver2.dobly_vision_signal = 1;/*0b0001*/
+
 	if ((debug_dolby & 2))
 		pr_dolby_dbg("src %d, dobly_vision_signal %d\n",
 			     src_format, vsif->vers.ver2.dobly_vision_signal);


### PR DESCRIPTION
## Summary

Send the canonical signal value 1 in the Dolby Vision VSIF when the output is player-led (low latency) Dolby Vision, the same as the 5.15 driver does. This lets strict sinks accept VS10-converted HDR10/SDR/HLG content.

## Problem

`prepare_vsif_pkt()` fills `dobly_vision_signal` in the Dolby Vision VSIF from the **source** format: Dolby Vision = 1, HDR10 = 3, HLG = 7, SDR/SDR BT.2020 = 5.

When VS10 converts an HDR10/HLG/SDR source to player-led (low latency) Dolby Vision, the HDMI output is plain LLDV, but the VSIF still carries 3/5/7. Those values set bits that are reserved in the LLDV VSIF, and strict sinks reject the infoframe. On an ASUS PG32UCDM3 the display never enters Dolby Vision for HDR10/SDR -> VS10 -> LLDV and shows a washed-out SDR picture, while native Dolby Vision (which already sends 1) works. `send_hdmi_pkt_ahead()` in the same file already hardcodes 1.

## How the newer 5.15 kernel handles this

In the 5.15 driver (CoreELEC/common_drivers, `5.15.196_20260225`, `drivers/media/enhancement/amdolby_vision/amdv.c`), `prepare_vsif_pkt()` wraps the 1/3/5/7 encoding in `#if NEW_DOLBY_SIGNAL_TYPE`, and the macro is defined as 0 at the top of the function:

- define: https://github.com/CoreELEC/common_drivers/blob/0a361009a997a298c8797ef3b4b58a5ee965f221/drivers/media/enhancement/amdolby_vision/amdv.c#L6665
- multi-DV path, L11 VSIF: https://github.com/CoreELEC/common_drivers/blob/0a361009a997a298c8797ef3b4b58a5ee965f221/drivers/media/enhancement/amdolby_vision/amdv.c#L6691-L6703
- multi-DV path, ver2 VSIF: https://github.com/CoreELEC/common_drivers/blob/0a361009a997a298c8797ef3b4b58a5ee965f221/drivers/media/enhancement/amdolby_vision/amdv.c#L6764-L6776
- legacy path: https://github.com/CoreELEC/common_drivers/blob/0a361009a997a298c8797ef3b4b58a5ee965f221/drivers/media/enhancement/amdolby_vision/amdv.c#L6818-L6830

```c
#define NEW_DOLBY_SIGNAL_TYPE 0
...
#if NEW_DOLBY_SIGNAL_TYPE
		if (src_format == FORMAT_DOVI || src_format == FORMAT_DOVI_LL)
			vsif->vers.ver2.dobly_vision_signal = 1;/*0b0001*/
		else if (src_format == FORMAT_HDR10)
			vsif->vers.ver2.dobly_vision_signal = 3;/*0b0011*/
		...
#else
		vsif->vers.ver2.dobly_vision_signal = 1;
#endif
```

So the 5.15 driver always sends 1, for every VSIF variant and for both LLDV and TV-led Dolby Vision.

## Change

This PR takes a narrower version of the same approach for the 4.9 driver. It sends 1 only when the output is low latency Dolby Vision (`setting->dovi_ll_enable`), and leaves TV-led Dolby Vision and all non-DV signalling unchanged. The L11 VSIF variant starts with the same bitfields, so it is covered too.

A module parameter, `dolby_vision_canonical_ll_signal` (default `Y`), restores the legacy 3/5/7 behaviour at runtime:

```
echo N > /sys/module/amdolby_vision/parameters/dolby_vision_canonical_ll_signal   # legacy 3/5/7
echo Y > /sys/module/amdolby_vision/parameters/dolby_vision_canonical_ll_signal   # canonical 1
```

This parameter is the only interface change: no exported symbol is added or changed.

## Test evidence

**Setup**
- S905X4 box, `dtb.img` = `sc2_s905x4_4g_1gbit.dtb`
- avdvplus R10 (CoreELEC 21.3, kernel 4.9.269, avdvplus/linux-amlogic `fb3ddc33`) rebuilt with this change, with dovi.ko and dovi5.ko loaded as usual
- ASUS PG32UCDM3. What the box reads from its EDID (`/sys/class/amhdmitx/amhdmitx0/dv_cap`):

```
DolbyVision RX support list:
VSVDB Version: V2
2160p60hz: 1
Support mode:
  LL_YCbCr_422_12BIT
  LL_RGB_444_12BIT
IEEEOUI: 0x00d046
VSVDB: eb0146d0004c0a6589626e8f
```

**Content:** SDR (BT.2020) source converted by VS10 to LLDV (`src_format` 6, `dolby_vision_ll_policy` 1).

**A/B test:** I toggled the parameter during playback, without restarting playback. This is the VSIF printed by hdmitx for each state:

`dolby_vision_canonical_ll_signal=Y` (this change):
```
***vsif_config_data***
type: 4, tunnel: 0, sigsdr: 0
dv_vsif_para:
ver: 0 len: 0
ll: 1 dvsig: 1
```

`dolby_vision_canonical_ll_signal=N` (legacy):
```
***vsif_config_data***
type: 4, tunnel: 0, sigsdr: 0
dv_vsif_para:
ver: 0 len: 0
ll: 1 dvsig: 5
```

HDMI output (`/sys/class/amhdmitx/amhdmitx0/config`), identical in both states:
```
VIC: 97 3840x2160p60hz        (also tested at VIC 93 3840x2160p24hz)
Colour depth: 12-bit
Colourspace: YUV422
EOTF: DV-LL
YCC colour range: limited
Colourimetry: BT.2020nc
```

| parameter | VSIF | display |
|---|---|---|
| `Y` (this change) | `ll: 1 dvsig: 1` | enters Dolby Vision, correct picture |
| `N` (legacy) | `ll: 1 dvsig: 5` | stays in SDR, washed-out picture |

Switching back and forth reproduces the fault and the fix every time. Native Dolby Vision playback is unaffected, because it sends 1 either way.

Before writing the in-kernel change, I got the same A/B result on the unmodified R10 kernel with a small diagnostic module that rewrote `dobly_vision_signal` to 1 in the `fresh_tx_vsif_pkt` hook. With it loaded, every VSIF passing through that hook was already 1, so nothing else in the output path changes this value. That confirmed the value alone is what the display reacts to.

## Scope of testing for this branch

The hardware testing above ran on the avdvplus R10 kernel, which is downstream of this branch and has the same `prepare_vsif_pkt()` logic. For `amlogic-4.9-20` the change is identical in logic, adapted to this file's formatting. It applies cleanly on top of `50c8e815`, but I haven't built or run this exact branch. I'm happy to test further if needed.

---

Developed with the assistance of Claude Code.
